### PR TITLE
Handle unescaped '$' as last character in string literals

### DIFF
--- a/pmd-powershell/src/main/antlr4/net/sourceforge/pmd/lang/powershell/antlr4/PowershellLexer.g4
+++ b/pmd-powershell/src/main/antlr4/net/sourceforge/pmd/lang/powershell/antlr4/PowershellLexer.g4
@@ -595,9 +595,9 @@ fragment EXPANDABLE_STRING_LITERAL_PART
    | EXPANDABLE_STRING_TRAILING_DOLLAR
    ;
 
-// Dollar as the last character of the string does not need to be escaped
+// Dollar as the last character of the string (or a line in a multiline string) does not need to be escaped
 fragment EXPANDABLE_STRING_TRAILING_DOLLAR
-   : DOLLAR { _input.LA(1) == '"' }?
+   : DOLLAR { _input.LA(1) == '"' || _input.LA(1) == '\n' || _input.LA(1) == '\r' }?
    ;
 
 SUBEXPR_START
@@ -635,7 +635,7 @@ fragment EXPANDABLE_HERE_STRING_PART
    ;
 
 fragment EXPANDABLE_HERE_STRING_TRAILING_DOLLAR
-   : DOLLAR { _input.LA(1) == '\n' }? // Dollars at the end of a line do not need to be escaped
+   : DOLLAR { _input.LA(1) == '\n' || _input.LA(1) == '\r'}? // Dollars at the end of a line do not need to be escaped
    ;
 
 MODE_EXPANDABLE_HERE_STRING_END

--- a/pmd-powershell/src/main/antlr4/net/sourceforge/pmd/lang/powershell/antlr4/PowershellLexer.g4
+++ b/pmd-powershell/src/main/antlr4/net/sourceforge/pmd/lang/powershell/antlr4/PowershellLexer.g4
@@ -303,11 +303,11 @@ fragment DOUBLE_QUOTE
 
 EXPANDABLE_STRING_START
    : DOUBLE_QUOTE
-   {_input.LA(1) != '@'}? -> pushMode(EXPANDABLE_STRING_MODE)
+   { _input.LA(1) != '@' }? -> pushMode(EXPANDABLE_STRING_MODE)
    ;
 
 EXPANDABLE_HERE_STRING_END
-   : DOUBLE_QUOTE '@'
+   : DOUBLE_QUOTE '@' { _input.LA(-3) == '\n' }?
    ;
 
 VERBATIM_HERE_STRING_START
@@ -323,7 +323,7 @@ VERBATIM_STRING
    ;
 
 fragment VERBATIM_STRING_PART
-   : ~ ('\u0027' | '\u2018' | '\u2019' | '\u201A' | '\u201B') // not SINGLE_QUOTE, cannot use SINGLE_QUOTE (https://github.com/antlr/antlr4/issues/70)
+   : ~ ('\u0027' | '\u2018' | '\u2019' | '\u201A' | '\u201B') // == ~(SINGLE_QUOTE), cannot use lexer rule for negation (https://github.com/antlr/antlr4/issues/70)
    | SINGLE_QUOTE SINGLE_QUOTE
    | NL
    ;
@@ -548,7 +548,7 @@ fragment Zs: [\p{Zs}];
 
 mode VERBATIM_STRING_MODE;
 fragment VERBATIM_MODE_STRING_PART
-   : ~ ('\u0027' | '\u2018' | '\u2019' | '\u201A' | '\u201B') // not SINGLE_QUOTE, cannot use SINGLE_QUOTE (https://github.com/antlr/antlr4/issues/70)
+   : ~ ('\u0027' | '\u2018' | '\u2019' | '\u201A' | '\u201B') // == ~(SINGLE_QUOTE), cannot use SINGLE_QUOTE (https://github.com/antlr/antlr4/issues/70)
    | SINGLE_QUOTE SINGLE_QUOTE
    ;
 
@@ -569,6 +569,7 @@ VERBATIM_HERE_STRING_PART
    // Single quote not preceded by NL
    | ~ ('\r' | '\n') SINGLE_QUOTE
    | NL SINGLE_QUOTE ~ ('@')
+   | NL
    ;
 
 VERBATIM_HERE_STRING_SECTION
@@ -576,7 +577,8 @@ VERBATIM_HERE_STRING_SECTION
    ;
 
 VERBATIM_HERE_STRING_END
-   : NL SINGLE_QUOTE '@' -> popMode
+   : SINGLE_QUOTE '@' { _input.LA(-3) == '\n' }?
+   -> popMode
    ;
 
 mode EXPANDABLE_STRING_MODE;
@@ -590,6 +592,12 @@ fragment EXPANDABLE_STRING_LITERAL_PART
    | DOLLAR ESCAPED_CHARACTER
    | ESCAPED_CHARACTER
    | DOUBLE_QUOTE DOUBLE_QUOTE
+   | EXPANDABLE_STRING_TRAILING_DOLLAR
+   ;
+
+// Dollar as the last character of the string does not need to be escaped
+fragment EXPANDABLE_STRING_TRAILING_DOLLAR
+   : DOLLAR { _input.LA(1) == '"' }?
    ;
 
 SUBEXPR_START
@@ -621,14 +629,15 @@ EXPANDABLE_HERE_STRING_VARIABLE
 
 fragment EXPANDABLE_HERE_STRING_PART
    : ~('\r' | '\n' | '$' | '@' | '"' | '\u201C' | '\u201D' | '\u201E')+
-   | DOLLAR NL ~ ('"') // Any Unicode character except double-quote-char
-   | NL ~ ('"' | '\u201C' // Left double quotation mark
-   | '\u201D' // Right double quotation mark
-   | '\u201E' | '@' | '\r' | '\n') // Any Unicode character except double-quote-char
+   | EXPANDABLE_HERE_STRING_TRAILING_DOLLAR
    | ~ ('\r' | '\n') DOUBLE_QUOTE
-   | NL DOUBLE_QUOTE ~ ('@') // Any Unicode character except @
+   | NL
+   ;
+
+fragment EXPANDABLE_HERE_STRING_TRAILING_DOLLAR
+   : DOLLAR { _input.LA(1) == '\n' }? // Dollars at the end of a line do not need to be escaped
    ;
 
 MODE_EXPANDABLE_HERE_STRING_END
-   : NL EXPANDABLE_HERE_STRING_END -> popMode, type(EXPANDABLE_HERE_STRING_END)
+   : EXPANDABLE_HERE_STRING_END -> popMode, type(EXPANDABLE_HERE_STRING_END)
    ;

--- a/pmd-powershell/src/main/antlr4/net/sourceforge/pmd/lang/powershell/antlr4/PowershellLexer.g4
+++ b/pmd-powershell/src/main/antlr4/net/sourceforge/pmd/lang/powershell/antlr4/PowershellLexer.g4
@@ -307,7 +307,7 @@ EXPANDABLE_STRING_START
    ;
 
 EXPANDABLE_HERE_STRING_END
-   : DOUBLE_QUOTE '@' { _input.LA(-3) == '\n' }?
+   : DOUBLE_QUOTE '@' { _input.LA(-3) == '\n' || _input.LA(-3) == '\r' }?
    ;
 
 VERBATIM_HERE_STRING_START
@@ -577,7 +577,7 @@ VERBATIM_HERE_STRING_SECTION
    ;
 
 VERBATIM_HERE_STRING_END
-   : SINGLE_QUOTE '@' { _input.LA(-3) == '\n' }?
+   : SINGLE_QUOTE '@' { _input.LA(-3) == '\n' || _input.LA(-3) == '\r' }?
    -> popMode
    ;
 

--- a/pmd-powershell/src/test/java/net/sourceforge/pmd/cpd/PowershellTokenizerTest.java
+++ b/pmd-powershell/src/test/java/net/sourceforge/pmd/cpd/PowershellTokenizerTest.java
@@ -39,4 +39,9 @@ public class PowershellTokenizerTest extends CpdTextComparisonTest {
     public void testStringLiterals() {
         doTest("String-Literal-Test");
     }
+
+    @Test
+    public void testExpStringDollarEnd() {
+        doTest("Regex-Interp");
+    }
 }

--- a/pmd-powershell/src/test/resources/net/sourceforge/pmd/lang/powershell/cpd/testdata/Initialize-Machine-Signed.txt
+++ b/pmd-powershell/src/test/resources/net/sourceforge/pmd/lang/powershell/cpd/testdata/Initialize-Machine-Signed.txt
@@ -3958,10 +3958,9 @@ L845
 L846
     [Write-Host]                            1         10
     [@']                                    12        13
-    [\n- Customize Startup items by loo[    14        46
-L850
-    [\n'@]                                  47        2
+    [\n- Customize Startup items by loo[    14        47
 L851
+    ['@]                                    1         2
     [-]                                     4         4
     [ForegroundColor]                       5         19
     [Cyan]                                  21        24

--- a/pmd-powershell/src/test/resources/net/sourceforge/pmd/lang/powershell/cpd/testdata/Regex-Interp.ps1
+++ b/pmd-powershell/src/test/resources/net/sourceforge/pmd/lang/powershell/cpd/testdata/Regex-Interp.ps1
@@ -1,0 +1,19 @@
+$RegexExample = "^\sExpandableString with a $var and some .* regex$";
+$AnotherExample = "^\sExpandableString with a $var";
+
+$RegexExample = @"
+^\sExpandableHereString with a $var and some .* regex$
+"@;
+
+$AnotherExample = @"
+^\sExpandableHereString with a $var
+"@;
+
+$AnotherExample = @"
+^\sExpandableHereString with a $var
+"@;
+
+$RegexExample = @"
+^\sExpandableHereString with a $var and some .* regex$
+and another line
+"@;

--- a/pmd-powershell/src/test/resources/net/sourceforge/pmd/lang/powershell/cpd/testdata/Regex-Interp.ps1
+++ b/pmd-powershell/src/test/resources/net/sourceforge/pmd/lang/powershell/cpd/testdata/Regex-Interp.ps1
@@ -17,3 +17,8 @@ $RegexExample = @"
 ^\sExpandableHereString with a $var and some .* regex$
 and another line
 "@;
+
+$multSring = "
+^\sExpandableHereString with a $var and some .* regex$
+and another line
+"

--- a/pmd-powershell/src/test/resources/net/sourceforge/pmd/lang/powershell/cpd/testdata/Regex-Interp.txt
+++ b/pmd-powershell/src/test/resources/net/sourceforge/pmd/lang/powershell/cpd/testdata/Regex-Interp.txt
@@ -60,4 +60,14 @@ L17
 L19
     ["@]                                    1         2
     [;]                                     3         3
+L21
+    [$multSring]                            1         10
+    [=]                                     12        12
+    ["]                                     14        14
+    [\n^\\sExpandableHereString with a ]    15        31
+L22
+    [$var]                                  32        35
+    [ and some .* regex$\nand another l[    36        17
+L24
+    ["]                                     1         1
 EOF

--- a/pmd-powershell/src/test/resources/net/sourceforge/pmd/lang/powershell/cpd/testdata/Regex-Interp.txt
+++ b/pmd-powershell/src/test/resources/net/sourceforge/pmd/lang/powershell/cpd/testdata/Regex-Interp.txt
@@ -1,0 +1,63 @@
+    [Image] or [Truncated image[            Bcol      Ecol
+L1
+    [$RegexExample]                         1         13
+    [=]                                     15        15
+    ["]                                     17        17
+    [^\\sExpandableString with a ]          18        44
+    [$var]                                  45        48
+    [ and some .* regex$]                   49        67
+    ["]                                     68        68
+    [;]                                     69        69
+L2
+    [$AnotherExample]                       1         15
+    [=]                                     17        17
+    ["]                                     19        19
+    [^\\sExpandableString with a ]          20        46
+    [$var]                                  47        50
+    ["]                                     51        51
+    [;]                                     52        52
+L4
+    [$RegexExample]                         1         13
+    [=]                                     15        15
+    [@"]                                    17        18
+    [\n^\\sExpandableHereString with a ]    19        31
+L5
+    [$var]                                  32        35
+    [ and some .* regex$\n]                 36        55
+L6
+    ["@]                                    1         2
+    [;]                                     3         3
+L8
+    [$AnotherExample]                       1         15
+    [=]                                     17        17
+    [@"]                                    19        20
+    [\n^\\sExpandableHereString with a ]    21        31
+L9
+    [$var]                                  32        35
+    [\n]                                    36        36
+L10
+    ["@]                                    1         2
+    [;]                                     3         3
+L12
+    [$AnotherExample]                       1         15
+    [=]                                     17        17
+    [@"]                                    19        20
+    [\n^\\sExpandableHereString with a ]    21        31
+L13
+    [$var]                                  32        35
+    [\n]                                    36        36
+L14
+    ["@]                                    1         2
+    [;]                                     3         3
+L16
+    [$RegexExample]                         1         13
+    [=]                                     15        15
+    [@"]                                    17        18
+    [\n^\\sExpandableHereString with a ]    19        31
+L17
+    [$var]                                  32        35
+    [ and some .* regex$\nand another l[    36        17
+L19
+    ["@]                                    1         2
+    [;]                                     3         3
+EOF

--- a/pmd-powershell/src/test/resources/net/sourceforge/pmd/lang/powershell/cpd/testdata/String-Literal-Test.txt
+++ b/pmd-powershell/src/test/resources/net/sourceforge/pmd/lang/powershell/cpd/testdata/String-Literal-Test.txt
@@ -34,13 +34,14 @@ L3
     [)]                                     148       148
     ["]                                     149       149
     [)]                                     150       150
-    [ which has more variables"]            151       176
-    [\n"@]                                  177       2
+    [ which has more variables"\n]          151       177
+L4
+    ["@]                                    1         2
 L5
     ['This string contains a subexpress[    1         152
 L6
     [@']                                    1         2
-    [\nThis here-string contains double[    3         176
-L7
-    [\n'@]                                  177       2
+    [\nThis here-string contains double[    3         177
+L8
+    ['@]                                    1         2
 EOF


### PR DESCRIPTION
In PowerShell, it is allowed to have an unescaped dollar sign in an expandable string literal (double quotes) in the following cases:
- It is the last character in a string
- It is the last character of a line in a multiline string

This caused lexical errors (see [PR33917](https://redmine.tiobe.com/issues/33917)); this pull request is to recognize this syntax.
